### PR TITLE
fixed libSBML path on linux

### DIFF
--- a/arFramework3/arCheck.m
+++ b/arFramework3/arCheck.m
@@ -119,7 +119,7 @@ if (exist('compileCeres', 'file') == 0)
     addpath([ar_path '/ThirdParty/Ceres'])
 end
 if (exist('TranslateSBML', 'file') == 0)
-    addpath([ar_path '/ThirdParty/libsbml'])
+    addpath([ar_path '/ThirdParty/libSBML'])
 end
 if (exist('fminsearchbnd', 'file') == 0)
     addpath([ar_path '/ThirdParty/FMINSEARCHBND'])


### PR DESCRIPTION
The addpath fails on linux for the libSBML subfolder.
This is case sensitive and the path is libSBML not libsbml

This fixes:
```
arInit
Warning: Name is nonexistent or not a directory:
/home/mkoenig/git/d2d/arFramework3/ThirdParty/libsbml 
> In path at 110
  In addpath at 87
  In arCheck at 122
  In arInit at 8 
```