### PR TITLE
Hierarchical optimization in D2D

### DIFF
--- a/arFramework3/Subfunctions/arCalcHierarchical.m
+++ b/arFramework3/Subfunctions/arCalcHierarchical.m
@@ -27,9 +27,20 @@ assert(isfield(ar.config,'useHierarchical') && ar.config.useHierarchical, ...
      'or there are no scale parameters suitable for hierarchical optimization in your observables.'])
 errorFitting = ( ar.config.fiterrors == 1) || (ar.config.fiterrors==0 && sum(ar.qFit(ar.qError==1)==1)>0 );
 assert(~errorFitting,'Hierarchical optimization in combination with with error fitting is not supported yet.')
+useCustomResidual = isfield(ar.config,'user_residual_fun') && ~isempty(ar.config.user_residual_fun);
+assert(~useCustomResidual,'Please choose between hierarchical optimization and custom residuals.')
+assert(~isfield(ar,'conditionconstraints'),'Hierarchical optimization in combination with condition constraints is not supported yet.')
 assert(sum(ar.type~=0)==0,'Hierarchical optimization in combination with priors other than flat box is not supported yet.')
+assert(~isfield(ar,'random'),'Hierarchical optimization in combination with random effects is not supported yet.')
+for im = 1:length(ar.model)
+    for ic = 1:length(ar.model(im).condition)
+        qssEnabled = isfield(ar.model(im).condition(ic), 'qSteadyState') && sum(ar.model(im).condition(ic).qSteadyState==1)>0;
+        assert(~qssEnabled,'Hierarchical optimization in combination with qSteadyState is not supported yet.')
+    end
+end
 for im = 1:length(ar.model)
     for id = 1:length(ar.model(im).data)
+        assert(all(ar.model(im).data(id).logfitting==0),'Please disable fitting of observables in log10 scale when using hierarchical optimization.')
         useCustomResidual = isfield( ar.model(im).data(id), 'resfunction' ) && isstruct( ar.model(im).data(id).resfunction ) && ar.model(im).data(id).resfunction.active;
         assert(~useCustomResidual,'Please choose between hierarchical optimization and custom residuals.')
     end

--- a/arFramework3/Subfunctions/arCalcHierarchical.m
+++ b/arFramework3/Subfunctions/arCalcHierarchical.m
@@ -124,6 +124,7 @@ for is = 1:length(ar.scales)
             denGrad = denGrad + 2*sum(xzExpSimu.*sxzExpSimu./(ystd.^2),1);
         end
     end
+    assert(den>0,sprintf('The solution of your model corresponding to the scale %s is zero at all measurement times. Hierarchical optimization is not feasible.',ar.scales(is).scaleLabel))
     ar.scales(is).scale = num/den;
     if sensi
         ar.scales(is).scaleGrad = (numGrad*den - denGrad*num)/(den^2);

--- a/arFramework3/Subfunctions/arCalcHierarchical.m
+++ b/arFramework3/Subfunctions/arCalcHierarchical.m
@@ -22,13 +22,20 @@ end
 
 global ar
 
+% Check settings which are required to carry out hierarchical optimization
 assert(isfield(ar.config,'useHierarchical') && ar.config.useHierarchical, ...
     ['Hierarchical optimization is not enabled. You have not called arInitHierarchical ', ...
      'or there are no scale parameters suitable for hierarchical optimization in your observables.'])
+for is = 1:length(ar.scales)
+    assert(~ar.qLog10(ar.scales(is).pLink),sprintf('Please disable log10 scale for parameter %s when using hierarchical optimization.',ar.pLabel{ar.scales(is).pLink}))
+    assert(ar.qFit(ar.scales(is).pLink)~=1,sprintf('Please disable fitting for parameter %s when using hierarchical optimization.',ar.pLabel{ar.scales(is).pLink}))
+end
+
+% Check for features which are yet not supported along with hierarchical optimization (but possibly may be supported in the future)
 errorFitting = ( ar.config.fiterrors == 1) || (ar.config.fiterrors==0 && sum(ar.qFit(ar.qError==1)==1)>0 );
 assert(~errorFitting,'Hierarchical optimization in combination with with error fitting is not supported yet.')
 useCustomResidual = isfield(ar.config,'user_residual_fun') && ~isempty(ar.config.user_residual_fun);
-assert(~useCustomResidual,'Please choose between hierarchical optimization and custom residuals.')
+assert(~useCustomResidual,'Hierarchical optimization in combination with custom residuals is not supported yet.')
 assert(~isfield(ar,'conditionconstraints'),'Hierarchical optimization in combination with condition constraints is not supported yet.')
 assert(sum(ar.type~=0)==0,'Hierarchical optimization in combination with priors other than flat box is not supported yet.')
 assert(~isfield(ar,'random'),'Hierarchical optimization in combination with random effects is not supported yet.')
@@ -40,14 +47,10 @@ for im = 1:length(ar.model)
 end
 for im = 1:length(ar.model)
     for id = 1:length(ar.model(im).data)
-        assert(all(ar.model(im).data(id).logfitting==0),'Please disable fitting of observables in log10 scale when using hierarchical optimization.')
+        assert(all(ar.model(im).data(id).logfitting==0),'Hierarchical optimization in combination with fitting of observables in log10 scale is not supported yet.')
         useCustomResidual = isfield( ar.model(im).data(id), 'resfunction' ) && isstruct( ar.model(im).data(id).resfunction ) && ar.model(im).data(id).resfunction.active;
-        assert(~useCustomResidual,'Please choose between hierarchical optimization and custom residuals.')
+        assert(~useCustomResidual,'Hierarchical optimization in combination with custom residuals is not supported yet.')
     end
-end
-for is = 1:length(ar.scales)
-    assert(~ar.qLog10(ar.scales(is).pLink),sprintf('Please disable log10 scale for parameter %s when using hierarchical optimization.',ar.pLabel{ar.scales(is).pLink}))
-    assert(ar.qFit(ar.scales(is).pLink)~=1,sprintf('Please disable fitting for parameter %s when using hierarchical optimization.',ar.pLabel{ar.scales(is).pLink}))
 end
 
 % For each data, extract corresponding xExpSimu/zExpSimu values and their sensitivities

--- a/arFramework3/Subfunctions/arCalcHierarchical.m
+++ b/arFramework3/Subfunctions/arCalcHierarchical.m
@@ -5,12 +5,13 @@ function arCalcHierarchical(sensi)
 %     corresponding condition structure.
 %   - Compute hierarchical scale parameters, overriding any custom values
 %     concerning these parameters.
-%   - For each data series with hierarchical scale parameter, recompute
-%     values of observables using the newly computed scale values,
-%     overriding the results of arSimu.
-%   - Do analogous things for the scales gradients and observables of
-%     sensitivities, based in sxExpSimu or szExpSimu fields in the
-%     condition structures.
+%   - For each data series with hierarchical scale parameter, use the newly
+%     computed scale value to recompute values of observables stored in the
+%     yExpSimu field, overriding the results of arSimu.
+%   - Do analogous things for the scale gradients and sensitivities of
+%     observables. Namely, compute scale gradients based on sxExpSimu or
+%     szExpSimu fields in the condition structures and subsequently
+%     recompute syExpSimu fields in the data structures.
 %
 %   The function takes sensi as an argument to expose interfece coherent
 %   with the convention of other d2d functions. However, this argument
@@ -122,5 +123,3 @@ for is = 1:length(ar.scales)
     end
 end
 % NOTE: Alternatively, we could iterate over the data instead of over the scales in the latter loop.
-
-% TODO: This function should update also yFineSimu.

--- a/arFramework3/Subfunctions/arCalcHierarchical.m
+++ b/arFramework3/Subfunctions/arCalcHierarchical.m
@@ -32,7 +32,17 @@ for is = 1:length(ar.scales)
 end
 
 % Check for features which are yet not supported along with hierarchical optimization (but possibly may be supported in the future)
-errorFitting = ( ar.config.fiterrors == 1) || (ar.config.fiterrors==0 && sum(ar.qFit(ar.qError==1)==1)>0 );
+if ar.config.fiterrors==0
+haveNanExpStd = false;
+for im = 1:length(ar.model)
+    for id = 1:length(ar.model(im).data)
+        if any(isnan(ar.model(im).data(id).yExpStd))
+            haveNanExpStd = true;
+        end
+    end
+end
+end
+errorFitting = ( (ar.config.fiterrors==1 || (ar.config.fiterrors==0 && haveNanExpStd)) && any(ar.qFit(ar.qError==1)==1) );
 assert(~errorFitting,'Hierarchical optimization in combination with with error fitting is not supported yet.')
 useCustomResidual = isfield(ar.config,'user_residual_fun') && ~isempty(ar.config.user_residual_fun);
 assert(~useCustomResidual,'Hierarchical optimization in combination with custom residuals is not supported yet.')

--- a/arFramework3/Subfunctions/arCalcHierarchical.m
+++ b/arFramework3/Subfunctions/arCalcHierarchical.m
@@ -1,0 +1,126 @@
+function arCalcHierarchical(sensi)
+%arCalcHierarchical Do the following things:
+%   - For each data series with hierarchical scale parameter, assign
+%     respective x or z values from the xExpSimu or zExpSimu field in the
+%     corresponding condition structure.
+%   - Compute hierarchical scale parameters, overriding any custom values
+%     concerning these parameters.
+%   - For each data series with hierarchical scale parameter, recompute
+%     values of observables using the newly computed scale values,
+%     overriding the results of arSimu.
+%   - Do analogous things for the scales gradients and observables of
+%     sensitivities, based in sxExpSimu or szExpSimu fields in the
+%     condition structures.
+%
+%   The function takes sensi as an argument to expose interfece coherent
+%   with the convention of other d2d functions. However, this argument
+%   is not used currently. The function always computes scale gradients
+%   and sensitivities of observables, regardless of the value of sensi.
+%   Put simply, if sxExpSimu or szExpSimu values are not up to date, then
+%   the resulting scale gradients and sensitivities of observables are not
+%   up to date. This is actually analogous to what happens with sxExpSimu
+%   and szExpSimu when calling arSimu with sensi set to false.
+
+if ~exist('sensi','var') || isempty(sensi)
+    sensi = 1;
+end
+
+global ar
+
+assert(isfield(ar.config,'useHierarchical') && ar.config.useHierarchical, ...
+    ['Hierarchical optimization is not enabled. You have not called arInitHierarchical ', ...
+     'or there are no scale parameters suitable for hierarchical optimization in your observables.'])
+errorFitting = ( ar.config.fiterrors == 1) || (ar.config.fiterrors==0 && sum(ar.qFit(ar.qError==1)==1)>0 );
+assert(~errorFitting,'Hierarchical optimization in combination with with error fitting is not supported yet.')
+assert(sum(ar.type~=0)==0,'Hierarchical optimization in combination with priors other than flat box is not supported yet.')
+for im = 1:length(ar.model)
+    for id = 1:length(ar.model(im).data)
+        useCustomResidual = isfield( ar.model(im).data(id), 'resfunction' ) && isstruct( ar.model(im).data(id).resfunction ) && ar.model(im).data(id).resfunction.active;
+        assert(~useCustomResidual,'Please choose between hierarchical optimization and custom residuals.')
+    end
+end
+for is = 1:length(ar.scales)
+    assert(~ar.qLog10(ar.scales(is).pLink),sprintf('Please disable log10 scale for parameter %s when using hierarchical optimization.',ar.pLabel{ar.scales(is).pLink}))
+    assert(ar.qFit(ar.scales(is).pLink)~=1,sprintf('Please disable fitting for parameter %s when using hierarchical optimization.',ar.pLabel{ar.scales(is).pLink}))
+end
+
+% For each data, extract corresponding xExpSimu/zExpSimu values and their sensitivities
+for im = 1:length(ar.model)
+    for id = 1:length(ar.model(im).data)
+
+        % This check is only for performance - continue early if no reason to stuck in this iteration
+        if all(isnan(ar.model(im).data(id).useHierarchical))
+            continue
+        end
+
+        ip = ar.model(im).data(id).pCondLink;
+        ic = ar.model(im).data(id).cLink;
+        td = ar.model(im).data(id).tExp;
+        tc = ar.model(im).condition(ic).tExp;
+        it = ismember(tc,td); % TODO: Test the performance of this function and possibly consider another solution
+
+        ar.model(im).data(id).xzExpSimu = zeros(sum(it),length(ar.model(im).data(id).fy));
+        ar.model(im).data(id).sxzExpSimu = zeros(sum(it),length(ar.model(im).data(id).fy),length(ar.model(im).data(id).p));
+        for iy = 1:length(ar.model(im).data(id).fy)
+            if ar.model(im).data(id).useHierarchical(iy)
+                ixz = ar.model(im).data(id).xzLink(iy);
+                xzType = ar.model(im).data(id).xzType{iy};
+                ar.model(im).data(id).xzExpSimu(:,iy) = ar.model(im).condition(ic).(sprintf('%sExpSimu',xzType))(it,ixz); % TODO: Test the performance impact of sprintf
+                ar.model(im).data(id).sxzExpSimu(:,iy,ip) = ar.model(im).condition(ic).(sprintf('s%sExpSimu',xzType))(it,ixz,:);
+            end
+        end
+
+    end
+end
+
+% Compute each scale parameter and their gradients
+for is = 1:length(ar.scales)
+    num = 0;
+    den = 0;
+    numGrad = 0;
+    denGrad = 0;
+    for il = 1:length(ar.scales(is).links)
+
+        im = ar.scales(is).links(il).m;
+        id = ar.scales(is).links(il).d;
+        iy = ar.scales(is).links(il).fy;
+        if ar.config.fiterrors == -1
+            ystd = ar.model(im).data(id).yExpStd(:,iy);
+        elseif ar.config.fiterrors == 0
+            ystd = ar.model(im).data(id).yExpStd(:,iy);
+            noSD = isnan(ystd);
+            ystd(noSD) = ar.model(im).data(id).ystdExpSimu(noSD,iy);
+        end
+        yExp = ar.model(im).data(id).yExp(:,iy);
+        xzExpSimu = ar.model(im).data(id).xzExpSimu(:,iy);
+        sxzExpSimu = squeeze(ar.model(im).data(id).sxzExpSimu(:,iy,:));
+
+        num = num + sum(yExp.*xzExpSimu./(ystd.^2));
+        den = den + sum(xzExpSimu.^2./(ystd.^2));
+
+        numGrad = numGrad + sum(yExp.*sxzExpSimu./(ystd.^2),1);
+        denGrad = denGrad + 2*sum(xzExpSimu.*sxzExpSimu./(ystd.^2),1);
+    end
+    ar.scales(is).scale = num/den;
+    ar.scales(is).scaleGrad = (numGrad*den - denGrad*num)/(den^2);
+    ar.p(ar.scales(is).pLink) = ar.scales(is).scale;
+end
+
+% Update observables and their sensitivities
+for is = 1:length(ar.scales)
+    scale = ar.scales(is).scale;
+    scaleGrad =  ar.scales(is).scaleGrad;
+    for il = 1:length(ar.scales(is).links)
+        im = ar.scales(is).links(il).m;
+        id = ar.scales(is).links(il).d;
+        iy = ar.scales(is).links(il).fy;
+        xzExpSimu = ar.model(im).data(id).xzExpSimu(:,iy);
+        sxzExpSimu = squeeze(ar.model(im).data(id).sxzExpSimu(:,iy,:));
+
+        ar.model(im).data(id).yExpSimu(:,iy) = scale.*xzExpSimu;
+        ar.model(im).data(id).syExpSimu(:,iy,:) = scale.*sxzExpSimu + scaleGrad.*xzExpSimu;
+    end
+end
+% NOTE: Alternatively, we could iterate over the data instead of over the scales in the latter loop.
+
+% TODO: This function should update also yFineSimu.

--- a/arFramework3/Subfunctions/arCalcRes.m
+++ b/arFramework3/Subfunctions/arCalcRes.m
@@ -100,6 +100,10 @@ end
 
 fiterrors_correction_factor = ar.config.fiterrors_correction;
 
+if isfield(ar.config,'useHierarchical') && ar.config.useHierarchical
+    arCalcHierarchical(sensi)
+end
+
 for m=1:length(ar.model)
     if ( isfield( ar.model(m), 'data' ) )
         for d=1:length(ar.model(m).data)

--- a/arFramework3/arDisableHierarchical.m
+++ b/arFramework3/arDisableHierarchical.m
@@ -1,0 +1,40 @@
+function arDisableHierarchical()
+%arDisableHierarchical Restore the original user settings overriden by
+%   arInitHierarchical and set ar.config.useHierarchical to false.
+%
+%   One may say that arInitHierarchical initializes the "hierarchical mode"
+%   of optimization and this function switches back to the "normal mode".
+%
+%   This function in particular attempts to restore the lower and upper
+%   bounds for the scale parameters subjected to hierarchical optimization.
+%   If the scales computed in the run of hierarchical optimization do not
+%   fit the original bounds, then these bounds are adjusted to cover the
+%   computed value.
+%
+%   See also ARINITHIERARCHICAL
+
+global ar
+
+assert(isfield(ar.config,'useHierarchical') && ar.config.useHierarchical, ...
+    ['Hierarchical optimization is not enabled. You have not called arInitHierarchical ', ...
+     'or there are no scale parameters suitable for hierarchical optimization in your observables.'])
+
+for is = 1:length(ar.scales)
+    pLink = ar.scales(is).pLink;
+    ar.qFit(pLink) = ar.scales(is).backup_user.qFit;
+    ar.qLog10(pLink) = ar.scales(is).backup_user.qLog10;
+    ar.lb(pLink) = ar.scales(is).backup_user.lb;
+    ar.ub(pLink) = ar.scales(is).backup_user.ub;
+    if isnan(ar.p(pLink)) % This happens when this function is called immediately after arInitHierarchical
+        ar.p(pLink) = ar.scales(is).backup_user.p;
+    elseif ar.qLog10(pLink) % Hierarchical mode always uses linear scale for the scale parameters, so when disabling this mode we apply the log10 scale if relevant
+        ar.p(pLink) = log10(ar.p(pLink));
+    end
+    if ar.lb(pLink) > ar.p(pLink)
+        ar.lb(pLink) = ar.lb(pLink) - 0.2*(ar.ub(pLink) - ar.lb(pLink));
+    elseif ar.ub(pLink) < ar.p(pLink)
+        ar.ub(pLink) = ar.ub(pLink) + 0.2*(ar.ub(pLink) - ar.lb(pLink));
+    end
+end
+
+ar.config.useHierarchical = false;

--- a/arFramework3/arInitHierarchical.m
+++ b/arFramework3/arInitHierarchical.m
@@ -220,18 +220,6 @@ else
     return
 end
 
-errorFitting = ( ar.config.fiterrors == 1) || (ar.config.fiterrors==0 && sum(ar.qFit(ar.qError==1)==1)>0 );
-if errorFitting
-    warning('Hierarchical optimization is not implemented to work with error fitting yet. Switching off error fitting (overriding your settings).')
-    ar.config.fiterrors == 0;
-    ar.qFit(boolean(ar.qError)) = 0;
-end
-
-if sum(ar.type~=0)>0
-    warning('Hierarchical optimization is not implemented to work with priors other than flat box yet. Setting all priors to flat box (overriding your settings).')
-    ar.type(:)=0;
-end
-
 function b = isNumericSym(x)
 
     assert(isa(x,'sym'),'Function defined only for symbolic variables.') % So we are sure that x has method char

--- a/arFramework3/arInitHierarchical.m
+++ b/arFramework3/arInitHierarchical.m
@@ -1,0 +1,169 @@
+function arInitHierarchical()
+%arInitHierarchical Find observables suitable for the hierarchical optimization
+%   and initialize necessary settings.
+%
+%   The suitable observables in question are those with linear dependence on
+%   a single species or derived variable, with the linearity coefficient not
+%   being a dynamic, initial nor error parameter. The present function creates
+%   structure ar.scales which gather information concerning these coefficients
+%   and sets ar.config.useHierarchical to true. This function also augments
+%   ar.model.data structures with some necessary fields. Moreover, it overrides
+%   some user settings, namely:
+%   - Settings in the global ar structure concerning the detected
+%     scale parameters.
+%   - Settings concerning the prior type (all priors are set to flat box).
+%   - Settings concerning error fitting (it is switched off).
+
+global ar;
+
+% We select observables obeying the following assumptions:
+%   1. The observable is a linear function of a single model species or derived variable.
+%   2. The parameter of that linear dependence is not defined in any other section except OBSERVABLES.
+% We test the the 2nd assumption above assuming that the inquired parameter should be none of
+% "dynamic", "initial" or "error".
+
+% Symbolic model species and derived variables
+xSyms = cellfun(@sym, ar.model.x, 'UniformOutput', false);
+zSyms = cellfun(@sym, ar.model.z, 'UniformOutput', false);
+
+% Symbolic dynamic, initial and error parameters
+pDynamicSyms = cellfun(@sym, ar.pLabel(boolean(ar.qDynamic)), 'UniformOutput', false);
+pInitialSyms = cellfun(@sym, ar.pLabel(boolean(ar.qInitial)), 'UniformOutput', false);
+pErrorSyms   = cellfun(@sym, ar.pLabel(boolean(ar.qError)), 'UniformOutput', false);
+
+% It will be convenient to have the "forbidden" syms in one array
+pForbiddenSyms = [pDynamicSyms(:)', pInitialSyms(:)', pErrorSyms(:)'];
+
+countScales = 0;
+if isfield(ar,'scales')
+  ar = rmfield(ar,'scales');
+end
+for im = 1:length(ar.model)
+  for id = 1:length(ar.model(im).data)
+    sz = size(ar.model(im).data(id).fy);
+    ar.model(im).data(id).useHierarchical = false(sz);
+    ar.model(im).data(id).scaleLink = nan(sz);
+    ar.model(im).data(id).xz = cellfun(@(c) '', cell(sz), 'UniformOutput', false);
+    ar.model(im).data(id).xzType = cellfun(@(c) '', cell(sz), 'UniformOutput', false);
+    ar.model(im).data(id).xzLink = nan(sz);
+    ar.model(im).data(id).xzExpSimuType = cellfun(@(c) '', cell(sz), 'UniformOutput', false);
+    ar.model(im).data(id).xzScale = cellfun(@(c) '', cell(sz), 'UniformOutput', false);
+    for iy = 1:length(ar.model(im).data(id).fy)
+
+      yFormula = str2sym(ar.model(im).data(id).fy{iy});
+      yPars = symvar(yFormula);
+
+      % We are interested in yFormulas of form xz_scale*xz where xz is a model
+      % species or a derived variable and xz_scale is a scale parameter, i.e.
+      % some new parameter not being a dynamic, initial or error parameter.
+      % We attempt to determine xz_scale as the derivative of yFormula
+      % w.r.t. xz.
+
+      % First, we check if yFormula contain exactly one xz
+      xzList = {};
+      for ip = 1:length(yPars)
+        for ix = 1:length(xSyms)
+          if isequal(yPars(ip),xSyms{ix})
+            xzList{end+1} = xSyms{ix};
+            xzType = 'x';
+          end
+        end
+        for iz = 1:length(zSyms)
+          if isequal(yPars(ip),zSyms{iz})
+            xzList{end+1} = zSyms{iz};
+            xzType = 'z';
+          end
+        end
+      end
+      if length(xzList)~=1
+        continue
+      else
+        xz = xzList{1};
+      end
+      % Second, we check if yFormula is of form xz_scale*xz
+      A = simplify(diff(yFormula,xz)); % This is our candidate for xz_scale
+      if length(children(A))~=1 % Apparently A is more complex than just a single parameter. Possibly yFormula is nonlinear.
+        continue
+      end
+      B = simplify(yFormula - A*xz);
+      if ~isAlways(B==0) % Apparently there is an extra term besides the one containing xz.
+        continue
+      end
+      xz_scale = A;
+      % Third, test if xz_scale is not a "forbidden" parameter
+      continue_flag = false;
+      for jp = 1:length(pForbiddenSyms)
+        if isequal(xz_scale,pForbiddenSyms{jp})
+          continue_flag = true;
+        end
+      end
+      if continue_flag
+        continue
+      end
+      % Fourth, test if xz_scale is not just a constant
+      if isSymType(xz_scale,'real') % TODO: Replace isSymType with something available in <R2019a
+        continue
+      end
+
+      % At this point, we know that yFormula=xz_scale*xz and have figured out
+      % both xz and xz_scale. Now, set necessary fields in the ar structure.
+
+      if ~isfield(ar,'scales')
+        idx = [];
+      else
+        idx = find(strcmp(cellfun(@(e) e, {ar.scales.scaleLabel}, 'UniformOutput', false), char(xz_scale)));
+      end
+      if isempty(idx)
+        countScales = countScales+1;
+        idx = countScales;
+        scaleLabel = char(xz_scale);
+        pLink = find(strcmp(scaleLabel,ar.pLabel));
+        ar.scales(idx).scaleLabel = scaleLabel;
+        ar.scales(idx).links(1).m = im;
+        ar.scales(idx).links(1).d = id;
+        ar.scales(idx).links(1).fy = iy;
+        ar.scales(idx).pLink = pLink;
+        ar.qFit(pLink) = 0;
+        ar.qLog10(pLink) = 0; % Hierarchical optimization assumes that scale parameters are considered in the plain linear scale
+        % These settings are technically not necessary but may help to avoid confusion
+        ar.p(pLink) = nan;
+        ar.lb(pLink) = 0;
+        ar.ub(pLink) = inf;
+      else
+        ar.scales(idx).links(end+1).m = im;
+        ar.scales(idx).links(end).d = id;
+        ar.scales(idx).links(end).fy = iy;
+      end
+      ar.model(im).data(id).useHierarchical(iy) = true;
+      ar.model(im).data(id).scaleLink(iy) = idx;
+      ar.model(im).data(id).xz{iy} = char(xz);
+      ar.model(im).data(id).xzType{iy} = xzType;
+      ar.model(im).data(id).xzLink(iy) = find(strcmp(char(xz),ar.model(im).(xzType)));
+      ar.model(im).data(id).xzScale{iy} = char(xz_scale);
+      for ip = 1:length(ar.model(im).data(id).p_condition)
+        ar.model(im).data(id).pCondLink(ip) = find(strcmp(ar.model(im).data(id).p_condition{ip}, ar.model(im).data(id).p));
+      end
+
+    end
+  end
+end
+
+if isfield(ar,'scales')
+    ar.config.useHierarchical = true;
+    disp(sprintf('Found %d scale parameters suitable for hierarchical optimization.',countScales))
+else
+    warning('No scale parameters found for hierarchical optimization.')
+    return
+end
+
+errorFitting = ( ar.config.fiterrors == 1) || (ar.config.fiterrors==0 && sum(ar.qFit(ar.qError==1)==1)>0 );
+if errorFitting
+    warning('Hierarchical optimization is not implemented to work with error fitting yet. Switching off error fitting (overriding your settings).')
+    ar.config.fiterrors == 0;
+    ar.qFit(boolean(ar.qError)) = 0;
+end
+
+if sum(ar.type~=0)>0
+    warning('Hierarchical optimization is not implemented to work with priors other than flat box yet. Setting all priors to flat box (overriding your settings).')
+    ar.type(:)=0;
+end

--- a/arFramework3/arInitHierarchical.m
+++ b/arFramework3/arInitHierarchical.m
@@ -46,7 +46,6 @@ for im = 1:length(ar.model)
     ar.model(im).data(id).xz = cellfun(@(c) '', cell(sz), 'UniformOutput', false);
     ar.model(im).data(id).xzType = cellfun(@(c) '', cell(sz), 'UniformOutput', false);
     ar.model(im).data(id).xzLink = nan(sz);
-    ar.model(im).data(id).xzExpSimuType = cellfun(@(c) '', cell(sz), 'UniformOutput', false);
     ar.model(im).data(id).xzScale = cellfun(@(c) '', cell(sz), 'UniformOutput', false);
     for iy = 1:length(ar.model(im).data(id).fy)
 

--- a/arFramework3/arInitHierarchical.m
+++ b/arFramework3/arInitHierarchical.m
@@ -9,6 +9,8 @@ function arInitHierarchical()
 %   and sets ar.config.useHierarchical to true. This function also augments
 %   ar.model.data structures with some necessary fields. Moreover, it overrides
 %   the user settings concerning the detected scale parameters.
+%
+%   See also ARDISABLEHIERARCHICAL
 
 global ar;
 
@@ -186,10 +188,17 @@ for k = 1:length(observableLinks)
     ar.scales(idx).links(1).d = id;
     ar.scales(idx).links(1).fy = iy;
     ar.scales(idx).pLink = pLink;
+    % Create a backup of user settings
+    ar.scales(idx).backup_user.qFit = ar.qFit(pLink);
+    ar.scales(idx).backup_user.qLog10 = ar.qLog10(pLink);
+    ar.scales(idx).backup_user.p = ar.p(pLink);
+    ar.scales(idx).backup_user.lb = ar.lb(pLink);
+    ar.scales(idx).backup_user.ub = ar.ub(pLink);
+    % Override user settings
     ar.qFit(pLink) = 0;
     ar.qLog10(pLink) = 0; % Hierarchical optimization assumes that scale parameters are considered in the plain linear scale
     % These settings are technically not necessary but may help to avoid confusion
-    ar.p(pLink) = nan;
+    ar.p(pLink) = nan; % Cf. arDisableHierarchical
     ar.lb(pLink) = 0;
     ar.ub(pLink) = inf;
   else

--- a/arFramework3/arInitHierarchical.m
+++ b/arFramework3/arInitHierarchical.m
@@ -5,14 +5,10 @@ function arInitHierarchical()
 %   The suitable observables in question are those with linear dependence on
 %   a single species or derived variable, with the linearity coefficient not
 %   being a dynamic, initial nor error parameter. The present function creates
-%   structure ar.scales which gather information concerning these coefficients
+%   structure ar.scales which gathers information concerning these coefficients
 %   and sets ar.config.useHierarchical to true. This function also augments
 %   ar.model.data structures with some necessary fields. Moreover, it overrides
-%   some user settings, namely:
-%   - Settings in the global ar structure concerning the detected
-%     scale parameters.
-%   - Settings concerning the prior type (all priors are set to flat box).
-%   - Settings concerning error fitting (it is switched off).
+%   the user settings concerning the detected scale parameters.
 
 global ar;
 

--- a/arFramework3/arInitHierarchical.m
+++ b/arFramework3/arInitHierarchical.m
@@ -100,7 +100,7 @@ for im = 1:length(ar.model)
         continue
       end
       % Fourth, test if xz_scale is not just a constant
-      if isSymType(xz_scale,'real') % TODO: Replace isSymType with something available in <R2019a
+      if isNumericSym(xz_scale)
         continue
       end
 
@@ -166,3 +166,10 @@ if sum(ar.type~=0)>0
     warning('Hierarchical optimization is not implemented to work with priors other than flat box yet. Setting all priors to flat box (overriding your settings).')
     ar.type(:)=0;
 end
+
+function b = isNumericSym(x)
+
+    assert(isa(x,'sym'),'Function defined only for symbolic variables.') % So we are sure that x has method char
+    y = str2double(char(x));
+    assert(numel(y)==1,'Excpected a single element.') % This should never happen, but, just in case, let's check it
+    b = ~isnan(y);

--- a/arFramework3/arSimu.m
+++ b/arFramework3/arSimu.m
@@ -49,6 +49,15 @@ else
     dynamics = 0;
 end
 
+% Computing scale parameters hierarchically requires the data grid, i.e. fine==false.
+% So in the case of a fine grid, i.e. fine==true, we need a double pass:
+% 1) simulate the model with the data grid to figure out the scale parameters and then
+% 2) simulate the model with a fine grid, using the scale parameters resulting from the previous step.
+% Here we carry out the 1st of these steps.
+if isfield(ar.config,'useHierarchical') && ar.config.useHierarchical && fine
+    arSimu(sensi,false,dynamics)
+end
+
 % If dynamics are not forced, check whether the dynamics of the last simulation
 % were identical. If not, we have to resimulate.
 if ( ~dynamics )


### PR DESCRIPTION
I have implemented a simple form of hierarchical optimization in D2D and I would like to propose to pull this feature upstream.

The method of hierarchical optimization is described in detail in [(Weber et al., 2011)](https://doi.org/10.3182/20110828-6-IT-1002.01007) and [(Loos et al.,2018)](https://doi.org/10.1093/bioinformatics/bty514). Let me however illustrate this method for the following simplified parameter estimation problem:

```
(Eq. 1) \min_{p} J_1(p) = \sum_{j=1}^{J} (Y_j - y(p,t_j))^2/{std}_j^2
```

where `Y_j` and `{std}_j` represent experimental measurements and associated standard deviations given or arbitrary scale and `y(p,t_j)` is the model observable corresponding to the measurements `Y_j`. Assume that the observable `y` is of form `y(p,t)=s*x(r,t)` where `x(r,t)` denote model species (or some derived variable) corresponding to the measurements `Y_j`, `s` is a scale parameter to be estimated along with the dynamic parameters `r` and `p=(r,s)`. Then, the above optimization problem becomes

```
(Eq. 2) \min_{r,s} J_2(r,s) = \sum_{j=1}^{J} (Y_j - s*x(r,t_j))^2/{std}_j^2
```

The core observation is that the function `J_2` is quadratic and positive definite w.r.t. the scale `s`, assuming that at least some of `x(r,t_j)` are nonzero. Thus, given parameters `r`, the optimal scale `s=s(r)` is uniquely determined and the optimization problem `(Eq. 2)` is equivalent to

```
(Eq. 3) \min_{r} J_3(r) = \sum_{j=1}^{J} (Y_j - s(r)*x(r,t_j))^2/{std}_j^2
```

The optimal scales `s(r)` may be expressed explicitly. To do so, it is enough to resolve the condition `\grad_{s} J_2(r,s)=0` w.r.t. `s`, which gives:

```
(Eq. 4) s(r) = \frac{\sum_{j} x_(r,t_j)*Y_j/{std}_j^2}
                    {\sum_{j} x_(r,t_j)^2/{std}_j^2}
```

Having this, we may also explicitly compute the gradient of `J_3` w.r.t. `r` (assuming that we can compute the sensitivities of `x` w.r.t `r`) and use it to feed any gradient-based optimization algorithm.

To sum up, thanks to the specific form of the observable `y`, namely `y=s*x`, we can replace the optimization problem `(Eq. 2)` with the equivalent problem `(Eq. 3)` which has less parameters to optimize. This is the method of hierarchical optimization. From my experience (and as one could expect), this can significantly improve the optimization speed. The trade off is that we need to assume a specific form of the observable `y`. Nevertheless, I think that the case of `y=s*x` is common enough to implement hierarchical optimization for it.

Theoretically, the method outlined above may be generalized to more complex observables, like e.g. `y=s*x+b` where `b` denotes an offset parameter. Such observables perhaps cover vast majority of practical applications. Having `y=s*x+b` we proceed analogously as above, namely instead of `(Eq. 2)` we have

```
(Eq. 2a) \min_{r,s,b} J_2(r,s,b) = \sum_{j=1}^{J} (Y_j - s*x(r,t_j) - b)^2/{std}_j^2
```

and we need to compute both the optimal scale `s=s(r)` and the optimal offset `b=b(r)`. The problem with such generalization is very pragmatic - the formulas for `s(r)` and `b(r)` become much more complex than in the simple case of `y=s*x` discussed above. For this reason I have implemented the hierarchical optimization just for the latter simple case and to be honest I think I will not implement the generalization to `y=s*x+b` soon.

# Usage

There is function `arInitHierarchical` which detects all observables of form `y=s*x` end enables the "hierarchical mode" of optimization. To get it work, just put `arInitHierarchical` before `arFit` (or `arFitLHS` or anything like that). There is also function `arDisableHierarchical` which switches back to the "normal mode". So an example setup with hierarchical optimization may look like this:

```matlab
arInit
arLoadModel(.....)
arLoadData(.....) % Assume that at least some data has observables of form y=s*x
arCompileAll

arFit % Here we optimize in the "normal mode", i.e. we optimize J_2(r,s) as in (Eq. 2)
arInitHierarchical % Here we enter the "hierarchial mode"...
arFit  % ... and fine-tune the fit by optimizing J_3(r) as in (Eq. 3)
arDisableHierarchical % Switch back to the "normal mode"
```

The optimal scales `s(r)` are computed by function `arCalcHierarchical`, which is called from `arCalcRes` and `arCalcSimu`. As a result, any D2D function that internally calls `arSimu` can benefit from the "hierarchical mode". For example, in the following snippet

```matlab
arInitHierarchical
arPlot
```

the scale parameters (if any) will be automatically fine-tuned prior to generating the plots.

# Limitations

The implementation in this pull request strongly relies on the specific form `(Eq. 2)` of the optimization problem. Consequently, any D2D feature that modifies `J_2` as in `(Eq. 2)` into something else cannot be used with the hierarchical optimization, at least until suitable generalizations are implemented. Up to what I know, these interfering features are:

* Interpreting observables and data in the log10 scale
* Error fitting
* The features handled in `arCollectRes`, namely:
    - Intercondition constraints and steady state conditions
    - Priors other than standard flat box
    - Random effects
    - User-defined residuals

With this features enabled, the current implementation of the hierarchical optimization works incorrectly since the optimal scales `s(r)` are in such case different than in `(Eq. 4)`. Function `arCalcHierarchical` raises an error if any of these features is in use. I have done my best to make the above list complete. However, I'm a newcomer to D2D so there may be some other features that I don't know yet and that may interfere with the hierarchical optimization by modifying the merit function `J_2`. _So if anybody finds that there are some more features like that in D2D, please let me know._

# Further development

The possible directions of generalization of the method are:

1. Add support for the hierarchical optimization for observables with offsets, `y=s*x+b`, possibly with some restricting assumptions.
2. Add support for the hierarchical optimization in combination with the features listed in the preceding section. In this respect, some features are more cumbersome than others. Specifically, support for priors should be simple to implement.
