### PR TITLE
Minor change: conversion to symbolic in MATLAB2020a

### DIFF
--- a/arFramework3/arCompileAll.m
+++ b/arFramework3/arCompileAll.m
@@ -2918,6 +2918,10 @@ function str = replaceDerivative( str )
 
         str = strrep( str, total{jm}, fNew );
     end
+    % because of compatibility with MATLAB2020a and later versions
+    if str2double(ver('MATLAB').Version) >= 9.8
+        str = strrep(str,';',',');
+    end
     
 % Safely map derivatives to the appropriate C functions
 %   pattern replaces D([#], func)(args) to Dfunc(args, floor(#/2)) 


### PR DESCRIPTION
It seems MATLAB2020a cannot convert some char strings to symbolic arrays. Apparently, the problem is because the expression which is going to be converted is a column vector. By replacing it with a row vector, MATLAB can handle the conversion. What I suggest is explicitly replacing semicolons with commas in MATLAB2020a and later versions.