### PR TITLE
[fix] Support for loading models for Mac M-series ARM Processor.

### DIFF
--- a/arFramework3/arLoad.m
+++ b/arFramework3/arLoad.m
@@ -84,7 +84,7 @@ fprintf('workspace loaded from file %s\n', workspace_name);
 % from the savefolder
 % Read out file ending of mex file for current os
 if ismac
-    osext = 'mexmaci64';
+    osext = append('mex', lower(computer()));
 elseif isunix
     osext = 'mexa64';
 elseif ispc


### PR DESCRIPTION
This allows the arLoad function to navigate the right model generated on Mac with Arm processors.